### PR TITLE
ADD alias for removing conflicting labels.

### DIFF
--- a/_posts/2016-02-22-a-pragmatic-workflow.md
+++ b/_posts/2016-02-22-a-pragmatic-workflow.md
@@ -128,7 +128,8 @@ We have created a handful of Git aliases that we're using to support this flow:
   purge-all-delivered = "!f() { git co `git default-branch`; git branch | grep 'delivered/' |   sed 's/delivered\\///g' | xargs -I %br sh -c 'git branch -D delivered/%br; git   push origin :%br' 2>/dev/null; }; f "
   default-branch = "!f(){ if git show-ref refs/heads/master >/dev/null 2>&1; then   echo master; elif git show-ref refs/heads/gh-pages >/dev/null 2>&1; then echo   gh-pages; fi; }; f"
   issue-branch = "!f() { MATCH=#$1:; ghi show $1 2>/dev/null | grep $MATCH | sed   s/$MATCH/$1/g | sed 's/ /-/g' | sed s/[:\\']//g; }; f"
-  issue-wip = "!f() { ghi label $1 'Status - in progress'; }; f"
+  issue-wip = "!f() { ghi label $1 'Status - in progress'; git remove-w-un $1; }; f"
+  remove-w-un = "!f() { ghi label $1 -d 'Status - workable'; ghi label $1 -d 'Status - up next'; }; f"
   work-on	= "!f() { BRANCH=`git issue-branch $1`; git fetch origin; git co $BRANCH   2> /dev/null || git co -b $BRANCH origin/`git default-branch`; git issue-wip $1; ghi assign $1;  }; f"
 {% endhighlight  %}
 


### PR DESCRIPTION
After configuring a Waffle.io board with labels "Status - workable" and "Status - up next", respectively on the boards Ready" or "Up Next" board. Waffle.io will set these labels to an issue, when it's manually moved to either of these boards.

When the "git work-on 123" command is invoked, ghi will assign the "Status - work in progress" to the issue, but the issue won't move on the board, because it's already in a column corresponding to a label on it, i.e. ".. - workable" or ".. - up next".

This alias will remove the "workable" and "up next" from the issue, irrespectively of whether they're set on it.

It also makes sense to remove this from an agile point of view,
- it it's being worked on, it's definitely ready, and 
- it's also not "up next" anymore; it's in progress.